### PR TITLE
feat: Add Test by Health Conditions and Promo Banners sections (#24)

### DIFF
--- a/frontend/src/components/HomeHero.jsx
+++ b/frontend/src/components/HomeHero.jsx
@@ -10,6 +10,8 @@ import {
 import WellnessPackagesSection from './WellnessPackagesSection'
 import TestByHealthRisks from './TestByHealthRisks'
 import MostPrescribedTests from './MostPrescribedTests'
+import TestByHealthConditions from './TestByHealthConditions'
+import PromoBanners from './PromoBanners'
 
 const FEATURES = [
   { icon: BadgeCheck, label: 'Most Trusted by Doctors' },
@@ -204,6 +206,8 @@ export default function HomeHero() {
       <WellnessPackagesSection />
       <TestByHealthRisks />
       <MostPrescribedTests />
+      <TestByHealthConditions />
+      <PromoBanners />
     </section>
   )
 }

--- a/frontend/src/components/PromoBanners.jsx
+++ b/frontend/src/components/PromoBanners.jsx
@@ -1,0 +1,64 @@
+export default function PromoBanners() {
+    return (
+        <section className="w-full pt-8 sm:pt-10 pb-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 sm:gap-6">
+
+                {/* Left banner — Acne / dark maroon */}
+                <article className="relative overflow-hidden rounded-2xl min-h-[200px] sm:min-h-[230px] bg-[#5a1a1a] flex items-stretch">
+                    {/* Background gradient overlay */}
+                    <div className="absolute inset-0 bg-gradient-to-r from-[#3d0e0e]/90 via-[#5a1a1a]/70 to-transparent z-10" />
+
+                    {/* Decorative person silhouette placeholder on the right */}
+                    <div className="absolute right-0 top-0 h-full w-2/5 bg-gradient-to-l from-[#7a2a2a]/40 to-transparent z-0 rounded-r-2xl" />
+
+                    {/* Text content */}
+                    <div className="relative z-20 p-6 sm:p-8 flex flex-col justify-center max-w-[60%]">
+                        <h3 className="text-xl sm:text-2xl font-extrabold text-[#ffd027] leading-tight mb-3">
+                            Unveiling the Hidden Causes of Acne with Pathkind Labs
+                        </h3>
+                        <p className="text-xs sm:text-sm text-gray-200 leading-relaxed mb-5">
+                            Are you tired of battling persistent acne? Do you yearn to discover the true root cause
+                            behind your skin troubles? Look no further than Pathkind Labs.
+                        </p>
+                        <button className="self-start h-9 px-6 rounded-full bg-[#ffd027] text-[#3d0e0e] font-bold text-xs sm:text-sm border-0 hover:bg-[#f0c000] transition-colors">
+                            Know More
+                        </button>
+                    </div>
+                </article>
+
+                {/* Right banner — Hairfall / light grey */}
+                <article className="relative overflow-hidden rounded-2xl min-h-[200px] sm:min-h-[230px] bg-gray-100 flex items-stretch">
+                    {/* Decorative person silhouette on the left */}
+                    <div className="absolute left-0 top-0 h-full w-2/5 bg-gradient-to-r from-gray-300/60 to-transparent z-0 rounded-l-2xl" />
+
+                    {/* Text content — right-aligned */}
+                    <div className="relative z-20 ml-auto p-6 sm:p-8 flex flex-col justify-center max-w-[60%] text-right">
+                        <p className="text-4xl sm:text-5xl font-black text-[#194b76] leading-none mb-1">
+                            60<span className="text-3xl sm:text-4xl">%</span>
+                        </p>
+                        <p className="text-lg sm:text-2xl font-extrabold text-[#2b2d37] leading-snug mb-1">
+                            Suffer Hairfall
+                        </p>
+                        <p className="text-sm sm:text-base font-bold text-[#ffd027] bg-[#194b76] rounded px-2 py-0.5 inline-block self-end mb-3">
+                            Are You at Risk?
+                        </p>
+                        <p className="text-xs sm:text-sm text-gray-500 mb-4">
+                            Know the root cause with
+                        </p>
+                        <div className="self-end">
+                            <span className="text-[#194b76] font-black text-lg sm:text-xl tracking-tight">
+                                Pathkind{' '}
+                                <span className="text-[#e8373f]">Hairfall</span>
+                                <span className="text-[#194b76]">Check</span>
+                            </span>
+                        </div>
+                        <button className="mt-4 self-end h-9 px-6 rounded-full bg-[#194b76] text-white font-bold text-xs sm:text-sm border-0 hover:bg-[#0e3a5e] transition-colors">
+                            Know More
+                        </button>
+                    </div>
+                </article>
+
+            </div>
+        </section>
+    )
+}

--- a/frontend/src/components/TestByHealthConditions.jsx
+++ b/frontend/src/components/TestByHealthConditions.jsx
@@ -1,0 +1,137 @@
+const CONDITIONS = [
+    {
+        id: 'alcohol',
+        label: 'Alcohol',
+        icon: (
+            <svg viewBox="0 0 40 40" fill="none" stroke="currentColor" strokeWidth="1.8" className="w-9 h-9">
+                <path d="M14 4h12l-3 14h-6L14 4z" strokeLinejoin="round" />
+                <path d="M17 18v14M23 18v14" />
+                <path d="M13 32h14" strokeLinecap="round" />
+                <circle cx="20" cy="11" r="2" />
+            </svg>
+        ),
+    },
+    {
+        id: 'allergy',
+        label: 'Allergy',
+        icon: (
+            <svg viewBox="0 0 40 40" fill="none" stroke="currentColor" strokeWidth="1.8" className="w-9 h-9">
+                <circle cx="20" cy="20" r="14" />
+                <circle cx="14" cy="16" r="3" />
+                <circle cx="26" cy="16" r="3" />
+                <path d="M14 26c1.5 3 10.5 3 12 0" strokeLinecap="round" />
+            </svg>
+        ),
+    },
+    {
+        id: 'anemia',
+        label: 'Anemia',
+        icon: (
+            <svg viewBox="0 0 40 40" fill="none" stroke="currentColor" strokeWidth="1.8" className="w-9 h-9">
+                <path d="M20 6C20 6 8 16 8 24a12 12 0 0024 0C32 16 20 6 20 6z" strokeLinejoin="round" />
+                <path d="M20 14v12M14 20h12" strokeLinecap="round" />
+            </svg>
+        ),
+    },
+    {
+        id: 'arthritis',
+        label: 'Arthritis',
+        icon: (
+            <svg viewBox="0 0 40 40" fill="none" stroke="currentColor" strokeWidth="1.8" className="w-9 h-9">
+                <line x1="20" y1="4" x2="20" y2="36" strokeLinecap="round" />
+                <circle cx="20" cy="14" r="4" />
+                <circle cx="20" cy="26" r="4" />
+                <path d="M12 20h16" strokeLinecap="round" />
+            </svg>
+        ),
+    },
+    {
+        id: 'cancer',
+        label: 'Cancer',
+        icon: (
+            <svg viewBox="0 0 40 40" fill="none" stroke="currentColor" strokeWidth="1.8" className="w-9 h-9">
+                <circle cx="20" cy="20" r="6" />
+                <path d="M20 6v6M20 28v6M6 20h6M28 20h6" strokeLinecap="round" />
+                <path d="M10.1 10.1l4.24 4.24M25.66 25.66l4.24 4.24M10.1 29.9l4.24-4.24M25.66 14.34l4.24-4.24" strokeLinecap="round" />
+            </svg>
+        ),
+    },
+    {
+        id: 'diabetes',
+        label: 'Diabetes',
+        icon: (
+            <svg viewBox="0 0 40 40" fill="none" stroke="currentColor" strokeWidth="1.8" className="w-9 h-9">
+                <rect x="12" y="8" width="16" height="24" rx="3" />
+                <path d="M16 8V6M24 8V6" strokeLinecap="round" />
+                <path d="M16 20h8M20 16v8" strokeLinecap="round" />
+            </svg>
+        ),
+    },
+    {
+        id: 'fever',
+        label: 'Fever',
+        icon: (
+            <svg viewBox="0 0 40 40" fill="none" stroke="currentColor" strokeWidth="1.8" className="w-9 h-9">
+                <rect x="18" y="6" width="5" height="20" rx="2.5" />
+                <circle cx="20.5" cy="29" r="5" />
+                <path d="M24 14h4M24 18h3M24 22h4" strokeLinecap="round" />
+            </svg>
+        ),
+    },
+    {
+        id: 'pregnancy',
+        label: 'Pregnancy',
+        icon: (
+            <svg viewBox="0 0 40 40" fill="none" stroke="currentColor" strokeWidth="1.8" className="w-9 h-9">
+                <circle cx="20" cy="9" r="4" />
+                <path d="M14 16h12l-2 16H16L14 16z" strokeLinejoin="round" />
+                <circle cx="20" cy="24" r="4" />
+            </svg>
+        ),
+    },
+    {
+        id: 'hepatitis',
+        label: 'Hepatitis',
+        icon: (
+            <svg viewBox="0 0 40 40" fill="none" stroke="currentColor" strokeWidth="1.8" className="w-9 h-9">
+                <path d="M20 6C12 10 8 16 8 22c0 6 5.4 12 12 12s12-6 12-12c0-6-4-12-12-16z" strokeLinejoin="round" />
+                <path d="M15 22h10M20 17v10" strokeLinecap="round" />
+            </svg>
+        ),
+    },
+]
+
+export default function TestByHealthConditions() {
+    return (
+        <section className="w-full pt-10 sm:pt-14 pb-6">
+            {/* Header */}
+            <div className="flex items-center justify-between mb-8 sm:mb-10">
+                <h2 className="text-2xl sm:text-4xl font-extrabold text-[#2b2d37]">
+                    Test by Health Conditions
+                </h2>
+                <button className="h-10 px-7 rounded-full bg-[#194b76] text-white font-semibold text-sm border-0 hover:bg-[#0e3a5e] transition-colors">
+                    View All
+                </button>
+            </div>
+
+            {/* Conditions grid */}
+            <div className="flex gap-4 sm:gap-6 overflow-x-auto pb-3 xl:grid xl:grid-cols-9"
+                style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}>
+                {CONDITIONS.map((cond) => (
+                    <div key={cond.id} className="flex flex-col items-center gap-3 flex-shrink-0">
+                        {/* Icon box */}
+                        <button
+                            aria-label={`View ${cond.label} tests`}
+                            className="h-[80px] w-[80px] sm:h-[90px] sm:w-[90px] rounded-2xl border border-gray-200 bg-white flex items-center justify-center text-[#2b2d37] shadow-sm hover:shadow-md hover:border-[#194b76] hover:text-[#194b76] transition-all duration-200"
+                        >
+                            {cond.icon}
+                        </button>
+                        <span className="text-sm sm:text-base font-semibold text-[#2b2d37]">
+                            {cond.label}
+                        </span>
+                    </div>
+                ))}
+            </div>
+        </section>
+    )
+}


### PR DESCRIPTION
- Created TestByHealthConditions.jsx
  - 9 health condition category tiles with inline SVG icons (Alcohol, Allergy, Anemia, Arthritis, Cancer, Diabetes, Fever, Pregnancy, Hepatitis)
  - Horizontal scroll on mobile, 9-col grid on desktop
  - Hover: border + icon colour shifts to navy, subtle shadow
- Created PromoBanners.jsx
  - Left card: dark maroon bg, 'Unveiling the Hidden Causes of Acne' headline with yellow CTA button and gradient overlay
  - Right card: light grey bg, '60% Suffer Hairfall' stat, Pathkind HairfallCheck branding, navy CTA button
  - Responsive: stacked on mobile, side-by-side md+
- Integrated both into HomeHero.jsx after MostPrescribedTests

Closes #24