### PR TITLE
fix: Replace all Pathkind/Healthkind references with Pathotest (#28)

### DIFF
--- a/frontend/src/components/HomeHero.jsx
+++ b/frontend/src/components/HomeHero.jsx
@@ -12,7 +12,7 @@ import TestByHealthRisks from './TestByHealthRisks'
 import MostPrescribedTests from './MostPrescribedTests'
 import TestByHealthConditions from './TestByHealthConditions'
 import PromoBanners from './PromoBanners'
-import WhyPathkindLabs from './WhyPathkindLabs'
+import WhyPathotestLabs from './WhyPathotestLabs'
 
 const FEATURES = [
   { icon: BadgeCheck, label: 'Most Trusted by Doctors' },
@@ -107,7 +107,7 @@ export default function HomeHero() {
             </h1>
 
             <div className="mt-4 inline-flex rounded-xl bg-[#ffd027] px-4 py-2 text-[#1f2c3a] font-semibold text-base sm:text-xl lg:text-2xl">
-              FREE with all Healthkind Packages.
+              FREE with all Pathotest Packages.
             </div>
 
             <p className="mt-4 text-xl sm:text-2xl lg:text-[27px] leading-snug text-blue-50 max-w-[420px]">
@@ -172,7 +172,7 @@ export default function HomeHero() {
                   onChange={handleChange('consent')}
                 />
                 <span>
-                  I authorize Pathkind Labs and its affiliates/representatives to contact me via phone calls, email, RCS, SMS or WhatsApp.
+                  I authorize Pathotest and its affiliates/representatives to contact me via phone calls, email, RCS, SMS or WhatsApp.
                 </span>
               </label>
 
@@ -209,7 +209,7 @@ export default function HomeHero() {
       <MostPrescribedTests />
       <TestByHealthConditions />
       <PromoBanners />
-      <WhyPathkindLabs />
+      <WhyPathotestLabs />
     </section>
   )
 }

--- a/frontend/src/components/OfferPopup.jsx
+++ b/frontend/src/components/OfferPopup.jsx
@@ -42,7 +42,7 @@ export default function OfferPopup({ open, onClose }) {
       <div
         role="dialog"
         aria-modal="true"
-        aria-label="Healthkind Full Body Checkup Offer"
+        aria-label="Pathotest Full Body Checkup Offer"
         className="relative bg-[#efefef] rounded-2xl shadow-2xl w-full max-w-[780px] max-h-[calc(100vh-2rem)] overflow-y-auto"
         onClick={stopPropagation}
       >
@@ -56,8 +56,8 @@ export default function OfferPopup({ open, onClose }) {
         </button>
 
         <img
-          src="/offers/healthkind-offer.png"
-          alt="Healthkind Full Body Checkup promotional offer"
+          src="/offers/pathotest-offer.png"
+          alt="Pathotest Full Body Checkup promotional offer"
           className="w-full h-auto rounded-t-2xl"
         />
 

--- a/frontend/src/components/PromoBanners.jsx
+++ b/frontend/src/components/PromoBanners.jsx
@@ -14,11 +14,11 @@ export default function PromoBanners() {
                     {/* Text content */}
                     <div className="relative z-20 p-6 sm:p-8 flex flex-col justify-center max-w-[60%]">
                         <h3 className="text-xl sm:text-2xl font-extrabold text-[#ffd027] leading-tight mb-3">
-                            Unveiling the Hidden Causes of Acne with Pathkind Labs
+                            Unveiling the Hidden Causes of Acne with Pathotest
                         </h3>
                         <p className="text-xs sm:text-sm text-gray-200 leading-relaxed mb-5">
                             Are you tired of battling persistent acne? Do you yearn to discover the true root cause
-                            behind your skin troubles? Look no further than Pathkind Labs.
+                            behind your skin troubles? Look no further than Pathotest.
                         </p>
                         <button className="self-start h-9 px-6 rounded-full bg-[#ffd027] text-[#3d0e0e] font-bold text-xs sm:text-sm border-0 hover:bg-[#f0c000] transition-colors">
                             Know More
@@ -47,7 +47,7 @@ export default function PromoBanners() {
                         </p>
                         <div className="self-end">
                             <span className="text-[#194b76] font-black text-lg sm:text-xl tracking-tight">
-                                Pathkind{' '}
+                                Pathotest{' '}
                                 <span className="text-[#e8373f]">Hairfall</span>
                                 <span className="text-[#194b76]">Check</span>
                             </span>

--- a/frontend/src/components/WellnessPackagesSection.jsx
+++ b/frontend/src/components/WellnessPackagesSection.jsx
@@ -2,7 +2,7 @@ import { ChevronLeft, ChevronRight, MessageCircle } from 'lucide-react'
 
 const PACKAGES = [
   {
-    name: 'HEALTHKIND TOTAL PLUS',
+    name: 'PATHOTEST TOTAL PLUS',
     profiles: 12,
     tests: 15,
     params: 87,
@@ -11,7 +11,7 @@ const PACKAGES = [
     discount: 74,
   },
   {
-    name: 'HEALTHKIND ADVANCE',
+    name: 'PATHOTEST ADVANCE',
     profiles: 15,
     tests: 19,
     params: 97,
@@ -20,7 +20,7 @@ const PACKAGES = [
     discount: 58,
   },
   {
-    name: 'HEALTHKIND PLATINUM',
+    name: 'PATHOTEST PLATINUM',
     profiles: 16,
     tests: 21,
     params: 99,
@@ -29,7 +29,7 @@ const PACKAGES = [
     discount: 57,
   },
   {
-    name: 'HEALTHKIND COMPLETE',
+    name: 'PATHOTEST COMPLETE',
     profiles: 13,
     tests: 17,
     params: 92,

--- a/frontend/src/components/WhyPathotestLabs.jsx
+++ b/frontend/src/components/WhyPathotestLabs.jsx
@@ -108,12 +108,12 @@ const FEATURES = [
     },
 ]
 
-export default function WhyPathkindLabs() {
+export default function WhyPathotestLabs() {
     return (
         <section className="w-full pt-10 sm:pt-14 pb-6">
             {/* Header */}
             <h2 className="text-2xl sm:text-4xl font-extrabold text-[#2b2d37] mb-8 sm:mb-10">
-                Why Pathkind Labs
+                Why Pathotest
             </h2>
 
             {/* 4 × 2 grid */}

--- a/frontend/src/test/AppOfferPopup.test.jsx
+++ b/frontend/src/test/AppOfferPopup.test.jsx
@@ -11,24 +11,24 @@ describe('App offer popup timing', () => {
     vi.useFakeTimers()
     render(<App />)
 
-    expect(screen.queryByRole('dialog', { name: /healthkind full body checkup offer/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('dialog', { name: /pathotest full body checkup offer/i })).not.toBeInTheDocument()
 
     act(() => {
       vi.advanceTimersByTime(119000)
     })
-    expect(screen.queryByRole('dialog', { name: /healthkind full body checkup offer/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('dialog', { name: /pathotest full body checkup offer/i })).not.toBeInTheDocument()
 
     act(() => {
       vi.advanceTimersByTime(1000)
     })
-    expect(screen.getByRole('dialog', { name: /healthkind full body checkup offer/i })).toBeInTheDocument()
+    expect(screen.getByRole('dialog', { name: /pathotest full body checkup offer/i })).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: /close offer popup/i }))
-    expect(screen.queryByRole('dialog', { name: /healthkind full body checkup offer/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('dialog', { name: /pathotest full body checkup offer/i })).not.toBeInTheDocument()
 
     act(() => {
       vi.advanceTimersByTime(120000)
     })
-    expect(screen.getByRole('dialog', { name: /healthkind full body checkup offer/i })).toBeInTheDocument()
+    expect(screen.getByRole('dialog', { name: /pathotest full body checkup offer/i })).toBeInTheDocument()
   })
 })

--- a/frontend/src/test/OfferPopup.test.jsx
+++ b/frontend/src/test/OfferPopup.test.jsx
@@ -4,14 +4,14 @@ import OfferPopup from '../components/OfferPopup'
 
 describe('OfferPopup', () => {
   it('does not render when closed', () => {
-    const { queryByRole } = render(<OfferPopup open={false} onClose={() => {}} />)
+    const { queryByRole } = render(<OfferPopup open={false} onClose={() => { }} />)
     expect(queryByRole('dialog')).not.toBeInTheDocument()
   })
 
   it('renders dialog and call link when open', () => {
-    render(<OfferPopup open={true} onClose={() => {}} />)
+    render(<OfferPopup open={true} onClose={() => { }} />)
 
-    expect(screen.getByRole('dialog', { name: /healthkind full body checkup offer/i })).toBeInTheDocument()
+    expect(screen.getByRole('dialog', { name: /pathotest full body checkup offer/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /call: 75000-75111/i })).toHaveAttribute('href', 'tel:+917500075111')
   })
 


### PR DESCRIPTION
- HomeHero.jsx: consent text, hero banner text, import rename
- WhyPathkindLabs.jsx → WhyPathotestLabs.jsx: file renamed, function name and 'Why Pathotest' heading updated
- WellnessPackagesSection.jsx: all 4 package names corrected (PATHOTEST TOTAL PLUS / ADVANCE / PLATINUM / COMPLETE)
- OfferPopup.jsx: aria-label, image src, and alt text corrected
- PromoBanners.jsx: acne banner text + HairfallCheck branding
- AppOfferPopup.test.jsx + OfferPopup.test.jsx: aria queries updated

Closes #28