### PR TITLE
feat: Add Sign In/Sign Up OTP modal from Navbar (#40)

### DIFF
--- a/.ai/changelog.txt
+++ b/.ai/changelog.txt
@@ -146,3 +146,25 @@ It documents every change made to the Pathotest codebase session by session.
 - Modified `frontend/src/App.jsx` — renders <Footer /> at bottom of every page
 - Branch: feat/site-footer
 
+
+---
+
+### [Issue #40] feat: Add Sign In/Sign Up modal triggered from Navbar Sign In button
+- Created `frontend/src/components/SignInModal.jsx`
+  - 2-step OTP flow: mobile number entry -> OTP verification
+  - Step 1: pill-shaped mobile input, consent checkbox (Pathotest branding),
+    "Generate OTP" full-width navy button
+  - Step 2: OTP input, "Verify & Continue" button, "Change number" back link
+  - Simulated OTP send (800ms timeout) — replace with real API call
+  - Footer: "By proceeding, you agree to Pathotest T&C and Privacy Policy"
+  - Close: X button top-right, backdrop click, or Escape key
+  - Body scroll locked while modal open
+  - State resets on each open
+- Modified `frontend/src/components/Navbar.jsx`
+  - Added `onSignInClick` prop
+  - Added navy pill "Sign In" button (id=navbar-sign-in) on the right end of navbar
+- Modified `frontend/src/App.jsx`
+  - Added `showSignIn` state
+  - Passed `onSignInClick={() => setShowSignIn(true)}` to Navbar
+  - Rendered `<SignInModal open={showSignIn} onClose=... />` alongside OfferPopup
+- Branch: feat/sign-in-modal

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,12 +7,14 @@ import ContactPage from './pages/ContactPage'
 import HomeHero from './components/HomeHero'
 import OfferPopup from './components/OfferPopup'
 import Footer from './components/Footer'
+import SignInModal from './components/SignInModal'
 
 const OFFER_POPUP_INTERVAL_MS = 120000
 
 function App() {
   const [page, setPage] = useState('home')
   const [showOfferPopup, setShowOfferPopup] = useState(false)
+  const [showSignIn, setShowSignIn] = useState(false)
 
   useEffect(() => {
     const timeoutId = window.setTimeout(() => {
@@ -36,7 +38,7 @@ function App() {
         onInvestorClick={() => setPage('investor')}
         onContactClick={() => setPage('contact')}
       />
-      <Navbar />
+      <Navbar onSignInClick={() => setShowSignIn(true)} />
 
       {page === 'investor' && <InvestorPage />}
       {page === 'contact' && <ContactPage />}
@@ -48,6 +50,7 @@ function App() {
       )}
 
       <OfferPopup open={showOfferPopup} onClose={() => setShowOfferPopup(false)} />
+      <SignInModal open={showSignIn} onClose={() => setShowSignIn(false)} />
       <Footer />
     </div>
   )

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -14,7 +14,7 @@ const RIGHT_LINKS = [
   { label: 'Upload Prescription', icon: UploadCloud, prefix: 'Rx' },
 ]
 
-export default function Navbar() {
+export default function Navbar({ onSignInClick }) {
   return (
     <nav className="w-full bg-white border-b border-gray-200">
       <div className="w-full px-4 sm:px-6 lg:px-10 h-12 md:h-14 flex items-center justify-between gap-4">
@@ -46,6 +46,16 @@ export default function Navbar() {
             </button>
           ))}
         </div>
+
+        {/* Sign In button */}
+        <button
+          type="button"
+          id="navbar-sign-in"
+          onClick={onSignInClick}
+          className="ml-2 flex-shrink-0 h-9 px-5 rounded-full bg-[#194b76] text-white font-semibold text-sm border-0 hover:bg-[#0e3a5e] transition-colors"
+        >
+          Sign In
+        </button>
       </div>
     </nav>
   )

--- a/frontend/src/components/SignInModal.jsx
+++ b/frontend/src/components/SignInModal.jsx
@@ -1,0 +1,177 @@
+import { useEffect, useState } from 'react'
+import { X } from 'lucide-react'
+
+export default function SignInModal({ open, onClose }) {
+    const [mobile, setMobile] = useState('')
+    const [consent, setConsent] = useState(true)
+    const [step, setStep] = useState('mobile') // 'mobile' | 'otp'
+    const [otp, setOtp] = useState('')
+    const [sending, setSending] = useState(false)
+
+    // Reset on open
+    useEffect(() => {
+        if (open) {
+            setMobile('')
+            setOtp('')
+            setStep('mobile')
+            setSending(false)
+        }
+    }, [open])
+
+    // Close on Escape
+    useEffect(() => {
+        if (!open) return undefined
+        const handler = (e) => { if (e.key === 'Escape') onClose() }
+        window.addEventListener('keydown', handler)
+        return () => window.removeEventListener('keydown', handler)
+    }, [open, onClose])
+
+    // Prevent body scroll while open
+    useEffect(() => {
+        if (!open) return undefined
+        const prev = document.body.style.overflow
+        document.body.style.overflow = 'hidden'
+        return () => { document.body.style.overflow = prev }
+    }, [open])
+
+    if (!open) return null
+
+    const handleMobileChange = (e) => {
+        const digits = e.target.value.replace(/\D/g, '').slice(0, 10)
+        setMobile(digits)
+    }
+
+    const handleGenerateOTP = (e) => {
+        e.preventDefault()
+        if (mobile.length !== 10) return
+        setSending(true)
+        // Simulate OTP send (real integration can replace this)
+        setTimeout(() => {
+            setSending(false)
+            setStep('otp')
+        }, 800)
+    }
+
+    const handleVerifyOTP = (e) => {
+        e.preventDefault()
+        // Placeholder — real verification goes here
+        onClose()
+    }
+
+    return (
+        /* Backdrop */
+        <div
+            role="presentation"
+            className="fixed inset-0 z-[1200] flex items-center justify-center bg-black/50 p-4"
+            onClick={onClose}
+        >
+            {/* Modal card */}
+            <div
+                role="dialog"
+                aria-modal="true"
+                aria-label="Sign In Sign Up Modal"
+                className="relative bg-white rounded-3xl shadow-2xl w-full max-w-[420px] px-6 py-8 sm:px-10 sm:py-10"
+                onClick={(e) => e.stopPropagation()}
+            >
+                {/* Close button */}
+                <button
+                    type="button"
+                    aria-label="Close sign in modal"
+                    onClick={onClose}
+                    className="absolute top-4 right-4 text-gray-400 hover:text-gray-700 transition-colors"
+                >
+                    <X size={22} />
+                </button>
+
+                {/* Heading */}
+                <h2 className="text-2xl font-extrabold text-[#2b2d37] text-center mb-2">
+                    Sign In/Sign Up to Continue
+                </h2>
+                <p className="text-sm text-center text-gray-500 mb-6 leading-snug">
+                    We&apos;ll confirm your booking shortly!<br />
+                    Please provide your number to receive updates.
+                </p>
+
+                {step === 'mobile' ? (
+                    <form onSubmit={handleGenerateOTP} className="space-y-5">
+                        {/* Mobile input */}
+                        <input
+                            id="sign-in-mobile"
+                            type="tel"
+                            inputMode="numeric"
+                            maxLength={10}
+                            placeholder="Enter Your Mobile"
+                            value={mobile}
+                            onChange={handleMobileChange}
+                            className="w-full h-13 px-5 py-3.5 rounded-full border border-gray-200 bg-gray-50 text-base text-gray-700 outline-none focus:ring-2 focus:ring-[#194b76] placeholder:text-gray-400"
+                            required
+                        />
+
+                        {/* Consent checkbox */}
+                        <label className="flex items-start gap-3 cursor-pointer text-sm text-gray-600 leading-snug">
+                            <input
+                                type="checkbox"
+                                checked={consent}
+                                onChange={(e) => setConsent(e.target.checked)}
+                                className="mt-0.5 h-5 w-5 rounded accent-[#194b76] flex-shrink-0"
+                            />
+                            <span>
+                                I authorize Pathotest and its affiliates/representatives to contact me via
+                                phone calls, email, RCS, SMS or WhatsApp.
+                            </span>
+                        </label>
+
+                        {/* Generate OTP button */}
+                        <button
+                            type="submit"
+                            disabled={mobile.length !== 10 || sending}
+                            className="w-full h-14 rounded-full bg-[#194b76] text-white font-bold text-xl border-0 hover:bg-[#0e3a5e] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                        >
+                            {sending ? 'Sending OTP…' : 'Generate OTP'}
+                        </button>
+                    </form>
+                ) : (
+                    /* OTP entry step */
+                    <form onSubmit={handleVerifyOTP} className="space-y-5">
+                        <p className="text-sm text-center text-gray-500">
+                            OTP sent to <span className="font-semibold text-[#194b76]">+91 {mobile}</span>
+                        </p>
+                        <input
+                            id="sign-in-otp"
+                            type="tel"
+                            inputMode="numeric"
+                            maxLength={6}
+                            placeholder="Enter OTP"
+                            value={otp}
+                            onChange={(e) => setOtp(e.target.value.replace(/\D/g, '').slice(0, 6))}
+                            className="w-full h-13 px-5 py-3.5 rounded-full border border-gray-200 bg-gray-50 text-base text-gray-700 outline-none focus:ring-2 focus:ring-[#194b76] placeholder:text-gray-400 tracking-widest text-center"
+                            required
+                        />
+                        <button
+                            type="submit"
+                            disabled={otp.length !== 6}
+                            className="w-full h-14 rounded-full bg-[#194b76] text-white font-bold text-xl border-0 hover:bg-[#0e3a5e] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                        >
+                            Verify &amp; Continue
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => setStep('mobile')}
+                            className="w-full text-sm text-[#194b76] hover:underline bg-transparent border-0"
+                        >
+                            ← Change number
+                        </button>
+                    </form>
+                )}
+
+                {/* Footer legal */}
+                <p className="mt-6 text-xs text-center text-gray-400">
+                    By proceeding, you agree to Pathotest{' '}
+                    <a href="#" className="text-[#194b76] underline">T&amp;C</a>
+                    {' '}and{' '}
+                    <a href="#" className="text-[#194b76] underline">Privacy Policy</a>.
+                </p>
+            </div>
+        </div>
+    )
+}


### PR DESCRIPTION
- Created SignInModal.jsx — 2-step modal:
  * Step 1: pill mobile input, Pathotest consent checkbox, Generate OTP button
  * Step 2: OTP input (6-digit), Verify & Continue, back to change number
  * Simulated OTP dispatch (swap for real API)
  * Close: X, backdrop click, Escape key; body-scroll locked
  * Footer: agree to Pathotest T&C and Privacy Policy
- Navbar.jsx: onSignInClick prop + navy pill 'Sign In' button (id=navbar-sign-in)
- App.jsx: showSignIn state, prop wired to Navbar, <SignInModal /> rendered
- .ai/changelog.txt: Issue #40 entry appended

Closes #40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Sign In modal with a two-step authentication flow: mobile number entry followed by OTP verification.
  * Added a Sign In button to the navbar for easy access.
  * Modal closes via backdrop click or Escape key, with automatic background scroll lock while open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->