### PR TITLE
fix: Wire Sign In modal to TopBar button, remove from Navbar (#41)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -37,8 +37,9 @@ function App() {
         onHomeClick={() => setPage('home')}
         onInvestorClick={() => setPage('investor')}
         onContactClick={() => setPage('contact')}
+        onSignInClick={() => setShowSignIn(true)}
       />
-      <Navbar onSignInClick={() => setShowSignIn(true)} />
+      <Navbar />
 
       {page === 'investor' && <InvestorPage />}
       {page === 'contact' && <ContactPage />}

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -14,7 +14,7 @@ const RIGHT_LINKS = [
   { label: 'Upload Prescription', icon: UploadCloud, prefix: 'Rx' },
 ]
 
-export default function Navbar({ onSignInClick }) {
+export default function Navbar() {
   return (
     <nav className="w-full bg-white border-b border-gray-200">
       <div className="w-full px-4 sm:px-6 lg:px-10 h-12 md:h-14 flex items-center justify-between gap-4">
@@ -46,16 +46,6 @@ export default function Navbar({ onSignInClick }) {
             </button>
           ))}
         </div>
-
-        {/* Sign In button */}
-        <button
-          type="button"
-          id="navbar-sign-in"
-          onClick={onSignInClick}
-          className="ml-2 flex-shrink-0 h-9 px-5 rounded-full bg-[#194b76] text-white font-semibold text-sm border-0 hover:bg-[#0e3a5e] transition-colors"
-        >
-          Sign In
-        </button>
       </div>
     </nav>
   )

--- a/frontend/src/components/TopBar.jsx
+++ b/frontend/src/components/TopBar.jsx
@@ -17,7 +17,7 @@ const UP_CITIES = [
   'Ayodhya',
 ]
 
-export default function TopBar({ onHomeClick }) {
+export default function TopBar({ onHomeClick, onInvestorClick, onContactClick, onSignInClick }) {
   const [selectedCity, setSelectedCity] = useState('Lucknow')
 
   return (
@@ -66,7 +66,11 @@ export default function TopBar({ onHomeClick }) {
             </div>
           </a>
 
-          <button className="flex items-center gap-1 text-sm sm:text-base font-semibold text-[#20232d] border-0 bg-transparent p-0">
+          <button
+            id="topbar-sign-in"
+            onClick={onSignInClick}
+            className="flex items-center gap-1 text-sm sm:text-base font-semibold text-[#20232d] border-0 bg-transparent p-0 hover:text-[#194b76] transition-colors"
+          >
             <UserRound size={18} />
             <LogIn size={16} className="-ml-2" />
             <span className="hidden sm:inline">Sign In</span>


### PR DESCRIPTION
- TopBar.jsx: added onSignInClick prop + id='topbar-sign-in' + hover:text-[#194b76] to the existing UserRound+LogIn Sign In button
- Navbar.jsx: removed duplicate Sign In button and onSignInClick prop
- App.jsx: moved onSignInClick={() => setShowSignIn(true)} from <Navbar> to <TopBar> so the correct button opens the modal

Closes #41